### PR TITLE
add missing semicolon to rust dockerfile

### DIFF
--- a/src/env/rust.py
+++ b/src/env/rust.py
@@ -4,7 +4,7 @@ _WORKDIR = "/app"
 _SRC_FILENAME = "main.rs"
 _CARGO_TOML = "Cargo.toml"
 
-_EMPTY_BRACKETS = "{{ App::new() }}"
+_EMPTY_BRACKETS = "{{ App::new(); }}"
 _RUST_DOCKERFILE = f"""
 #setup base
 FROM rust:1.83.0-alpine3.20


### PR DESCRIPTION
I was running into this:
```
error[E0308]: mismatched types
 --> src/main.rs:1:33
  |
1 | use actix_web::App; fn main() { App::new() }
  |                              -  ^^^^^^^^^^- help: consider using a semicolon here: `;`
  |                              |  |
  |                              |  expected `()`, found `App<AppEntry>`
  |                              expected `()` because of default return type
  |
  = note: expected unit type `()`
                found struct `App<actix_web::app_service::AppEntry>`
```