### PR TITLE
Pin goimports version to v0.36.0

### DIFF
--- a/src/env/go.py
+++ b/src/env/go.py
@@ -18,7 +18,7 @@ FROM golang:1.23-bullseye
 # prebuild/prefetch deps
 RUN mkdir -p {_WORKDIR}
 RUN apt-get install gcc build-essential -y # Required to make CGO work
-RUN go install golang.org/x/tools/cmd/goimports@latest
+RUN go install golang.org/x/tools/cmd/goimports@v0.36.0
 WORKDIR {_WORKDIR}
 COPY {_GO_MOD_FILENAME} {_BUILD_HELPER_FILENAME} ./
 RUN go get {_GO_APP_NAME}


### PR DESCRIPTION
To avoid a version conflict with go 1.23.x